### PR TITLE
[REFACTOR]: 댓글 생성, 수정, 삭제 로직 (#72)

### DIFF
--- a/src/main/java/kr/co/deundeun/groopy/controller/comment/CommentController.java
+++ b/src/main/java/kr/co/deundeun/groopy/controller/comment/CommentController.java
@@ -19,16 +19,15 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/applies/{applyId}/comments")
-    public ResponseEntity<Void> CommentApply(@Me User user, @PathVariable Long applyId,
-                                             @Valid @RequestBody CommentRequestDto commentRequestDto) {
-        commentService.commentApply(user, applyId, commentRequestDto);
-
+    public ResponseEntity<Void> commentClubApply(@Me User user, @PathVariable Long applyId,
+                                                 @Valid @RequestBody CommentRequestDto commentRequestDto) {
+        commentService.commentClubApply(user, applyId, commentRequestDto);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/applies/{applyId}/comments")
-    public ResponseEntity<List<CommentResponseDto>> getComments(@PathVariable Long applyId) {
-        return ResponseEntity.ok(commentService.getApplyComments(applyId));
+    public ResponseEntity<List<CommentResponseDto>> getClubApplyComments(@PathVariable Long applyId) {
+        return ResponseEntity.ok(commentService.getClubApplyComments(applyId));
     }
 
     @PatchMapping("/comments/{commentId}")
@@ -42,5 +41,29 @@ public class CommentController {
     public ResponseEntity<Void> deleteComment(@Me User user, @PathVariable Long commentId) {
         commentService.deleteComment(user, commentId);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/posts/{postId}/comments")
+    public ResponseEntity<Void> commentPost(@Me User user, @PathVariable Long postId,
+                                             @Valid @RequestBody CommentRequestDto commentRequestDto) {
+        commentService.commentPost(user, postId, commentRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<List<CommentResponseDto>> getPostComments(@PathVariable Long postId) {
+        return ResponseEntity.ok(commentService.getPostComments(postId));
+    }
+
+    @PostMapping("/recruits/{recruitId}/comments")
+    public ResponseEntity<Void> commentClubRecruit(@Me User user, @PathVariable Long recruitId,
+                                            @Valid @RequestBody CommentRequestDto commentRequestDto) {
+        commentService.commentClubRecruit(user, recruitId, commentRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/recruits/{recruitId}/comments")
+    public ResponseEntity<List<CommentResponseDto>> getClubRecruitComments(@PathVariable Long recruitId) {
+        return ResponseEntity.ok(commentService.getClubRecruitComments(recruitId));
     }
 }

--- a/src/main/java/kr/co/deundeun/groopy/domain/clubApply/ClubApply.java
+++ b/src/main/java/kr/co/deundeun/groopy/domain/clubApply/ClubApply.java
@@ -37,6 +37,8 @@ public class ClubApply extends BaseEntity {
     @OneToMany(mappedBy = "clubApply")
     private List<Comment> comments = new ArrayList<>();
 
+    private int commentCount = 0;
+
     @Builder
     public ClubApply(User user, ClubRecruit clubRecruit, List<String> clubApplyAnswers) {
         this();
@@ -67,6 +69,17 @@ public class ClubApply extends BaseEntity {
 
     public void setClubApplyStatus(ClubApplyStatus clubApplyStatus){
         this.clubApplyStatus = clubApplyStatus;
+    }
+
+    public void increaseCommentCount(){
+        this.commentCount += 1;
+    }
+
+    public void decreaseCommentCount(){
+        if (this.commentCount <= 0){
+            return;
+        }
+        this.commentCount -= 1;
     }
 
 }

--- a/src/main/java/kr/co/deundeun/groopy/domain/clubRecruit/ClubRecruit.java
+++ b/src/main/java/kr/co/deundeun/groopy/domain/clubRecruit/ClubRecruit.java
@@ -59,6 +59,8 @@ public class ClubRecruit extends BaseEntity {
 
     private int likeCount = 0;
 
+    private int commentCount = 0;
+
     private int applicantCount = 0;
 
     @OneToMany(mappedBy = "clubRecruit")
@@ -106,10 +108,23 @@ public class ClubRecruit extends BaseEntity {
     }
 
     public void decreaseApplicantCount(){
-        if (this.applicantCount != 0) {
-            this.applicantCount -= 1;
+        if (this.applicantCount <= 0) {
+            return;
         }
+        this.applicantCount -= 1;
     }
+
+    public void increaseCommentCount(){
+        this.commentCount += 1;
+    }
+
+    public void decreaseCommentCount(){
+        if (this.commentCount <= 0){
+            return;
+        }
+        this.commentCount -= 1;
+    }
+
     public int getQuestionSize(){
         return this.getClubApplyForm().getClubRecruitQuestions().size();
     }

--- a/src/main/java/kr/co/deundeun/groopy/domain/post/Post.java
+++ b/src/main/java/kr/co/deundeun/groopy/domain/post/Post.java
@@ -1,5 +1,6 @@
 package kr.co.deundeun.groopy.domain.post;
 
+import java.util.ArrayList;
 import javax.persistence.*;
 
 import kr.co.deundeun.groopy.dto.post.PostRequestDto;
@@ -35,7 +36,7 @@ public class Post extends BaseEntity {
     private int viewCount = 0;
 
     @OneToMany(mappedBy = "post")
-    private List<Comment> comments;
+    private List<Comment> comments = new ArrayList<>();
 
     public Post(PostRequestDto postRequestDto){
         this.title = postRequestDto.getTitle();
@@ -68,4 +69,14 @@ public class Post extends BaseEntity {
         else likeCount = 0;
     }
 
+    public void increaseCommentCount(){
+        this.commentCount += 1;
+    }
+
+    public void decreaseCommentCount(){
+        if (commentCount <= 0 ) {
+            return;
+        }
+        this.commentCount -= 1;
+    }
 }

--- a/src/main/java/kr/co/deundeun/groopy/dto/comment/CommentRequestDto.java
+++ b/src/main/java/kr/co/deundeun/groopy/dto/comment/CommentRequestDto.java
@@ -1,8 +1,10 @@
 package kr.co.deundeun.groopy.dto.comment;
 
 import kr.co.deundeun.groopy.domain.clubApply.ClubApply;
+import kr.co.deundeun.groopy.domain.clubRecruit.ClubRecruit;
 import kr.co.deundeun.groopy.domain.comment.Comment;
 import kr.co.deundeun.groopy.domain.comment.constant.CommentType;
+import kr.co.deundeun.groopy.domain.post.Post;
 import kr.co.deundeun.groopy.domain.user.User;
 import lombok.Getter;
 
@@ -19,22 +21,36 @@ public class CommentRequestDto {
 
     private Long parentCommentId;
 
-    public Comment toComment(User user, ClubApply clubApply) {
+    public Comment toClubApplyComment(User user, ClubApply clubApply, Comment parentComment) {
+        clubApply.increaseCommentCount();
         return Comment.builder()
-                .user(user)
-                .commentType(commentType)
-                .comment(comment)
-                .clubApply(clubApply)
-                .build();
+                      .commentType(commentType)
+                      .user(user)
+                      .comment(comment)
+                      .clubApply(clubApply)
+                      .parentComment(parentComment)
+                      .build();
     }
 
-    public Comment toComment(User user, ClubApply clubApply, Comment parentComment) {
+    public Comment toPostComment(User user, Post post, Comment parentComment) {
+        post.increaseCommentCount();
         return Comment.builder()
-                .user(user)
-                .commentType(commentType)
-                .comment(comment)
-                .clubApply(clubApply)
-                .parentComment(parentComment)
-                .build();
+                      .commentType(commentType)
+                      .user(user)
+                      .comment(comment)
+                      .post(post)
+                      .parentComment(parentComment)
+                      .build();
+    }
+
+    public Comment toClubRecruitComment(User user, ClubRecruit clubRecruit, Comment parentComment) {
+        clubRecruit.increaseCommentCount();
+        return Comment.builder()
+                      .commentType(commentType)
+                      .user(user)
+                      .comment(comment)
+                      .clubRecruit(clubRecruit)
+                      .parentComment(parentComment)
+                      .build();
     }
 }

--- a/src/main/java/kr/co/deundeun/groopy/dto/comment/CommentResponseDto.java
+++ b/src/main/java/kr/co/deundeun/groopy/dto/comment/CommentResponseDto.java
@@ -23,19 +23,25 @@ public class CommentResponseDto {
 
     private LocalDateTime createdAt;
 
-    public static List<CommentResponseDto> ofList(List<Comment> comments){
-        return comments.stream()
-                .map(CommentResponseDto::new)
-                .collect(Collectors.toList());
-    }
-
     public CommentResponseDto(Comment comment){
         this.id = comment.getId();
         this.commentType = comment.getCommentType();
         this.comment = comment.getComment();
         this.author = comment.getUser().getNickname();
-        if(comment.getParentComment() != null)
-        this.parentCommentId = comment.getParentComment().getId();
+        this.parentCommentId = getParentCommentId(comment);
         this.createdAt = comment.getCreatedAt();
+    }
+
+    private Long getParentCommentId(Comment comment) {
+        if (comment.getParentComment() == null) {
+            return -1L;
+        }
+        return comment.getParentComment().getId();
+    }
+
+    public static List<CommentResponseDto> ofList(List<Comment> comments){
+        return comments.stream()
+                       .map(CommentResponseDto::new)
+                       .collect(Collectors.toList());
     }
 }

--- a/src/main/java/kr/co/deundeun/groopy/helper/CommentHelper.java
+++ b/src/main/java/kr/co/deundeun/groopy/helper/CommentHelper.java
@@ -9,14 +9,13 @@ import kr.co.deundeun.groopy.exception.IdNotFoundException;
 
 public class CommentHelper {
 
-    public static Comment findById(CommentRepository commentRepository, Long id, User user) {
-        Comment comment = findById(commentRepository, id);
-        if (!user.equals(comment.getUser())) throw new AuthorizationException();
-        return comment;
-    }
-
     public static Comment findById(CommentRepository commentRepository, Long id) {
         return commentRepository.findById(id)
                 .orElseThrow(() -> new IdNotFoundException("존재하지 않는 댓글 ID 입니다."));
+    }
+
+    public static Comment findParentCommentById(CommentRepository commentRepository, Long parentCommentId){
+        if (parentCommentId == -1L) return null;
+        return commentRepository.findById(parentCommentId).orElse(null);
     }
 }

--- a/src/main/java/kr/co/deundeun/groopy/service/CommentService.java
+++ b/src/main/java/kr/co/deundeun/groopy/service/CommentService.java
@@ -1,5 +1,9 @@
 package kr.co.deundeun.groopy.service;
 
+import kr.co.deundeun.groopy.dao.ClubRecruitRepository;
+import kr.co.deundeun.groopy.dao.PostRepository;
+import kr.co.deundeun.groopy.domain.clubRecruit.ClubRecruit;
+import kr.co.deundeun.groopy.domain.post.Post;
 import kr.co.deundeun.groopy.dto.comment.CommentRequestDto;
 import kr.co.deundeun.groopy.dto.comment.CommentResponseDto;
 import kr.co.deundeun.groopy.dao.ClubApplyRepository;
@@ -7,56 +11,88 @@ import kr.co.deundeun.groopy.dao.CommentRepository;
 import kr.co.deundeun.groopy.domain.clubApply.ClubApply;
 import kr.co.deundeun.groopy.domain.comment.Comment;
 import kr.co.deundeun.groopy.domain.user.User;
+import kr.co.deundeun.groopy.exception.AuthorizationException;
 import kr.co.deundeun.groopy.exception.LoginException;
 import kr.co.deundeun.groopy.helper.ClubApplyHelper;
+import kr.co.deundeun.groopy.helper.ClubRecruitHelper;
 import kr.co.deundeun.groopy.helper.CommentHelper;
+import kr.co.deundeun.groopy.helper.PostHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class CommentService {
 
     private final CommentRepository commentRepository;
-
     private final ClubApplyRepository clubApplyRepository;
+    private final PostRepository postRepository;
+    private final ClubRecruitRepository clubRecruitRepository;
 
-    public void commentApply(User user, Long applyId, CommentRequestDto commentRequestDto) {
+    @Transactional
+    public void commentClubApply(User user, Long applyId, CommentRequestDto commentRequestDto) {
+
         if (user.getId() == null) throw new LoginException();
+
         ClubApply clubApply = ClubApplyHelper.findById(clubApplyRepository, applyId);
-
-        Comment comment;
-
-        Long parentCommentId = commentRequestDto.getParentCommentId();
-        if (parentCommentId != null) {
-            Comment parentComment = CommentHelper
-                    .findById(commentRepository, parentCommentId);
-            comment = commentRequestDto.toComment(user, clubApply, parentComment);
-        } else {
-            comment = commentRequestDto.toComment(user, clubApply);
-        }
+        Comment parentComment = CommentHelper.findParentCommentById(commentRepository, commentRequestDto.getParentCommentId());
+        Comment comment = commentRequestDto.toClubApplyComment(user, clubApply, parentComment);
         commentRepository.save(comment);
-        clubApplyRepository.save(clubApply);
     }
 
-    public List<CommentResponseDto> getApplyComments(Long applyId) {
+    public List<CommentResponseDto> getClubApplyComments(Long applyId) {
         ClubApply clubApply = ClubApplyHelper.findById(clubApplyRepository, applyId);
-        List<Comment> comments = commentRepository.findByClubApply(clubApply);
+        List<Comment> comments = clubApply.getComments();
         return CommentResponseDto.ofList(comments);
     }
 
+    @Transactional
     public void updateComment(User user, Long commentId, CommentRequestDto commentRequestDto) {
-        Comment comment = CommentHelper.findById(commentRepository, commentId, user);
-        comment.update(commentRequestDto);
-        commentRepository.save(comment);
+        Comment comment = CommentHelper.findById(commentRepository, commentId);
+        if (!user.equals(comment.getUser())) throw new AuthorizationException();
+        comment.updateComment(commentRequestDto);
     }
 
+    @Transactional
     public void deleteComment(User user, Long commentId) {
-        Comment comment = CommentHelper.findById(commentRepository, commentId, user);
+        Comment comment = CommentHelper.findById(commentRepository, commentId);
+        if (!user.equals(comment.getUser())) throw new AuthorizationException();
+        comment.deleteRelationship();
         commentRepository.delete(comment);
     }
 
 
+    @Transactional
+    public void commentPost(User user, Long postId, CommentRequestDto commentRequestDto) {
+        if (user.getId() == null) throw new LoginException(); // 근데 user가 없을 때, getId해도 되나?
+        Post post = PostHelper.findById(postRepository, postId);
+        Comment parentComment = CommentHelper.findParentCommentById(commentRepository, commentRequestDto.getParentCommentId());
+        Comment comment = commentRequestDto.toPostComment(user, post, parentComment);
+        commentRepository.save(comment);
+    }
+
+    public List<CommentResponseDto> getPostComments(Long postId) {
+        Post post = PostHelper.findById(postRepository, postId);
+        List<Comment> comments = post.getComments();
+        return CommentResponseDto.ofList(comments);
+    }
+
+    @Transactional
+    public void commentClubRecruit(User user, Long clubRecruitId, CommentRequestDto commentRequestDto){
+        if (user.getId() == null) throw new LoginException(); // 근데 user가 없을 때, getId해도 되나?
+        ClubRecruit clubRecruit = ClubRecruitHelper.findById(clubRecruitRepository, clubRecruitId);
+        Comment parentComment = CommentHelper.findParentCommentById(commentRepository, commentRequestDto.getParentCommentId());
+        Comment comment = commentRequestDto.toClubRecruitComment(user, clubRecruit, parentComment);
+        commentRepository.save(comment);
+    }
+
+
+    public List<CommentResponseDto> getClubRecruitComments(Long clubRecruitId){
+        ClubRecruit clubRecruit = ClubRecruitHelper.findById(clubRecruitRepository, clubRecruitId);
+        List<Comment> comments = clubRecruit.getComments();
+        return CommentResponseDto.ofList(comments);
+    }
 }


### PR DESCRIPTION
### 1. 아래의 포스트 참고해서, parentComment 로직 수정
> http://homoefficio.github.io/2019/10/03/Java-Optional-%EB%B0%94%EB%A5%B4%EA%B2%8C-%EC%93%B0%EA%B8%B0/

### 2. `CommentRequest`  와 `CommentResponse` 모두 parentId가 없을 시에는 -1 값을 입력받고 출력함

### 3. delete 로직 구현